### PR TITLE
Version 2.1.1

### DIFF
--- a/classes/checkout-gateway.php
+++ b/classes/checkout-gateway.php
@@ -185,10 +185,7 @@ class Checkout_Gateway extends WC_Payment_Gateway {
 			ZCO()->logger()->error( sprintf( 'Zaver error during payment process: %s', $e->getMessage() ), Helper::add_zaver_error_details( $e, array( 'orderId' => $order_id ) ) );
 
 			$message = __( 'An error occurred - please try again, or contact site support', 'zco' );
-			wc_add_notice( $message, 'error' );
-			return array(
-				'result' => 'error',
-			);
+			throw new Exception( esc_html( $message ) );
 		}
 	}
 

--- a/classes/helpers/order.php
+++ b/classes/helpers/order.php
@@ -43,6 +43,7 @@ class Order {
 		$store_id = preg_replace( '/(https?:\/\/|www.|\/\s*$)/i', '', get_home_url() );
 
 		$billing_address = ( new Address() )
+		->setName( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() )
 		->setAddressLine1( $order->get_billing_address_1() )
 		->setAddressLine2( $order->get_billing_address_2() )
 		->setCity( $order->get_billing_city() )
@@ -51,6 +52,7 @@ class Order {
 		->setCountry( $order->get_billing_country() );
 
 		$shipping_address = ( new Address() )
+		->setName( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() )
 		->setAddressLine1( $order->get_shipping_address_1() )
 		->setAddressLine2( $order->get_shipping_address_2() )
 		->setPostalCode( $order->get_shipping_postcode() )

--- a/classes/session.php
+++ b/classes/session.php
@@ -89,7 +89,8 @@ class Session {
 		} catch ( \Exception $e ) {
 			\Zaver\ZCO()->logger()->critical(
 				'Failed to retrieve payment methods',
-				Helper::add_zaver_error_details( $e,
+				Helper::add_zaver_error_details(
+					$e,
 					array(
 						'payload' => array(
 							'total'    => $total,
@@ -123,10 +124,14 @@ class Session {
 		$id              = str_replace( 'zaver_checkout_', '', strtolower( $id ) );
 		$payment_methods = WC()->session->get( 'zaver_checkout_available_payment_methods' );
 		if ( ! empty( $payment_methods ) ) {
-			foreach ( $payment_methods[ $market ][ $currency ][ $total ] as $payment_method ) {
-				$payment_method_id = strtolower( $payment_method['paymentMethod'] );
-				if ( $payment_method_id === $id ) {
-					return true;
+			$zaver_payment_methods = $payment_methods[ $market ][ $currency ][ $total ] ?? array();
+
+			if ( ! empty( $zaver_payment_methods ) ) {
+				foreach ( $zaver_payment_methods as $payment_method ) {
+					$payment_method_id = strtolower( $payment_method['paymentMethod'] ?? '' );
+					if ( ! empty( $payment_method_id ) && $payment_method_id === $id ) {
+						return true;
+					}
 				}
 			}
 		}

--- a/composer.lock
+++ b/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "1692c7de7f6d8b92bf71c22093b3e89068f7cd7d"
+                "reference": "ef96143054f60a2f0b2cfe8351f5d78448729e98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/1692c7de7f6d8b92bf71c22093b3e89068f7cd7d",
-                "reference": "1692c7de7f6d8b92bf71c22093b3e89068f7cd7d",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/ef96143054f60a2f0b2cfe8351f5d78448729e98",
+                "reference": "ef96143054f60a2f0b2cfe8351f5d78448729e98",
                 "shasum": ""
             },
             "require": {
@@ -50,20 +50,20 @@
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
                 "source": "https://github.com/php-stubs/woocommerce-stubs/tree/master"
             },
-            "time": "2025-10-31T22:13:04+00:00"
+            "time": "2026-03-12T19:28:12+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.3",
+            "version": "v6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "abeb5a8b58fda7ac21f15ee596f302f2959a7114"
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/abeb5a8b58fda7ac21f15ee596f302f2959a7114",
-                "reference": "abeb5a8b58fda7ac21f15ee596f302f2959a7114",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
                 "shasum": ""
             },
             "conflict": {
@@ -74,9 +74,10 @@
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -99,9 +100,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
             },
-            "time": "2025-09-30T20:58:47+00:00"
+            "time": "2026-02-03T19:29:21+00:00"
         },
         {
             "name": "wpify/php-scoper",
@@ -206,11 +207,11 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4.0"
     },

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: krokedil
 Tags: woocommerce, zaver, checkout, payment, refund, swish
 Stable tag: 2.1.0
 Requires at least: 4.7
-Tested up to: 6.8.3
+Tested up to: 6.9
 Requires PHP: 7.4
-WC tested up to: 10.2.2
+WC tested up to: 10.3.5
 License: GNU General Public License v3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Stable tag: 2.1.0
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 7.4
-WC tested up to: 10.3.5
+WC tested up to: 10.5.0
 License: GNU General Public License v3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -50,9 +50,10 @@ To get started with Zaver you need to sign up for an account. Once you have gone
 5. Get paid. ✌️
 
 == Changelog ==
-= 2026.03.24    - version 2.1.1 =
+= 2026.03.25    - version 2.1.1 =
 * Fix           - Updated error handling for recent WooCommerce changes so payment failures now display the actual error message instead of a generic one.
 * Fix           - Added the billing/shipping recipient name to the address sent in payment requests to Zaver.
+* Fix           - Resolved PHP warnings that could occur during checkout when certain data was not yet set.
 
 = 2025.11.10    - version 2.1.0 =
 * Feature       - Added support for updating Zaver orders with a reduced price for PAY_LATER and INSTALLMENTS payment types, before the payment is captured or cancelled.

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Zaver Checkout for WooCommerce ===
 Contributors: krokedil
 Tags: woocommerce, zaver, checkout, payment, refund, swish
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 Requires at least: 4.7
 Tested up to: 6.9
 Requires PHP: 7.4
-WC tested up to: 10.5.0
+WC tested up to: 10.6.1
 License: GNU General Public License v3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,6 +50,10 @@ To get started with Zaver you need to sign up for an account. Once you have gone
 5. Get paid. ✌️
 
 == Changelog ==
+= 2026.03.24    - version 2.1.1 =
+* Fix           - Updated error handling for recent WooCommerce changes so payment failures now display the actual error message instead of a generic one.
+* Fix           - Added the billing/shipping recipient name to the address sent in payment requests to Zaver.
+
 = 2025.11.10    - version 2.1.0 =
 * Feature       - Added support for updating Zaver orders with a reduced price for PAY_LATER and INSTALLMENTS payment types, before the payment is captured or cancelled.
 

--- a/src/PaymentMethods/BaseGateway.php
+++ b/src/PaymentMethods/BaseGateway.php
@@ -67,7 +67,7 @@ abstract class BaseGateway extends WC_Payment_Gateway {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->has_fields   = false;
+		$this->has_fields = false;
 
 		$this->init_form_fields();
 		$this->init_settings();
@@ -186,10 +186,7 @@ abstract class BaseGateway extends WC_Payment_Gateway {
 			\Zaver\ZCO()->logger()->error( sprintf( 'Zaver error during payment process: %s', $e->getMessage() ), \Zaver\Helper::add_zaver_error_details( $e, array( 'orderId' => $order_id ) ) );
 
 			$message = __( 'An error occurred - please try again, or contact site support', 'zco' );
-			wc_add_notice( $message, 'error' );
-			return array(
-				'result' => 'error',
-			);
+			throw new Exception( esc_html( $message ) );
 		}
 	}
 

--- a/woocommerce-zaver-checkout.php
+++ b/woocommerce-zaver-checkout.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 10.3.5
+ * WC tested up to: 10.5.0
  * Requires Plugins: woocommerce
  *
  * License: GNU General Public License v3.0

--- a/woocommerce-zaver-checkout.php
+++ b/woocommerce-zaver-checkout.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 10.2.2
+ * WC tested up to: 10.3.5
  * Requires Plugins: woocommerce
  *
  * License: GNU General Public License v3.0

--- a/woocommerce-zaver-checkout.php
+++ b/woocommerce-zaver-checkout.php
@@ -3,7 +3,7 @@
  * Plugin Name: Zaver Checkout for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/zaver-checkout-for-woocommerce/
  * Description: The official Zaver Checkout payment gateway for WooCommerce.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Author: Zaver
  * Author URI: https://zaver.com/woocommerce
  * Developer: Krokedil
@@ -12,7 +12,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 6.0.0
- * WC tested up to: 10.5.0
+ * WC tested up to: 10.6.1
  * Requires Plugins: woocommerce
  *
  * License: GNU General Public License v3.0
@@ -41,7 +41,7 @@ define( 'ZCO_PLUGIN_PATH', __DIR__ );
  * Handles the plugins initialization.
  */
 class Plugin {
-	public const VERSION        = '2.1.0';
+	public const VERSION        = '2.1.1';
 	public const PAYMENT_METHOD = 'zaver_checkout';
 
 	/**


### PR DESCRIPTION
* Fix - Updated error handling for recent WooCommerce changes so payment failures now display the actual error message instead of a generic one.
* Fix - Added the billing/shipping recipient name to the address sent in payment requests to Zaver.
* Fix - Resolved PHP warnings that could occur during checkout when certain data was not yet set.
